### PR TITLE
Raw Time Series Extractor Integration Tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,10 +8,25 @@ from cognite.extractorutils.base import CancellationToken
 from cognite.extractorutils.metrics import safe_get
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.extractor import CdfFabricExtractor
 from dotenv import load_dotenv
-from tests.integration.integration_steps.cdf_steps import remove_time_series_data, push_time_series_to_cdf, create_subscription_in_cdf
-from tests.integration.integration_steps.fabric_steps import get_ts_delta_table
-from tests.integration.integration_steps.time_series_generation import generate_timeseries_set
+from tests.integration.integration_steps.cdf_steps import (
+    remove_time_series_data,
+    push_time_series_to_cdf,
+    create_subscription_in_cdf,
+    remove_subscriptions,
+)
+from tests.integration.integration_steps.fabric_steps import (
+    get_ts_delta_table,
+    write_timeseries_data_to_fabric,
+    remove_time_series_data_from_fabric,
+)
+from tests.integration.integration_steps.time_series_generation import (
+    generate_timeseries_set,
+    generate_raw_timeseries_set,
+    generate_timeseries,
+)
+import pandas as pd
 
 load_dotenv()
 
@@ -28,6 +43,23 @@ def test_replicator():
         os.remove("states.json")
     except FileNotFoundError:
         pass
+
+
+@pytest.fixture(scope="session")
+def test_extractor():
+    stop_event = CancellationToken()
+    exatractor = CdfFabricExtractor(stop_event=stop_event)
+    exatractor._initial_load_config(override_path=os.environ["TEST_CONFIG_PATH"])
+    exatractor.client = exatractor.config.cognite.get_cognite_client(exatractor.name)
+    exatractor.cognite_client = exatractor.config.cognite.get_cognite_client(exatractor.name)
+    exatractor._load_state_store()
+    exatractor.logger = Mock()
+    yield exatractor
+    try:
+        os.remove("states.json")
+    except FileNotFoundError:
+        pass
+
 
 @pytest.fixture(scope="session")
 def cognite_client():
@@ -62,8 +94,40 @@ def lakehouse_timeseries_path(azure_credential):
 def time_series(request, cognite_client):
     sub_name = "testSubscription"
     timeseries_set = generate_timeseries_set(request.param)
-    remove_time_series_data(timeseries_set, sub_name, cognite_client)
+    remove_time_series_data(timeseries_set, cognite_client)
+    remove_subscriptions(sub_name, cognite_client)
     push_time_series_to_cdf(timeseries_set, cognite_client)
     create_subscription_in_cdf(timeseries_set, sub_name, cognite_client)
     yield timeseries_set
-    remove_time_series_data(timeseries_set, sub_name, cognite_client)
+    remove_time_series_data(timeseries_set, cognite_client)
+    remove_subscriptions(sub_name, cognite_client)
+
+@pytest.fixture(scope="function")
+def raw_time_series(request, azure_credential, cognite_client, test_extractor):
+    timeseries_set = generate_raw_timeseries_set(request.param)
+    df = pd.DataFrame(timeseries_set, columns=["externalId", "timestamp", "value"])
+    remove_time_series_data_from_fabric(
+        azure_credential,
+        test_extractor.config.source.abfss_prefix + "/" + test_extractor.config.source.raw_time_series_path
+    )
+    write_timeseries_data_to_fabric(
+        azure_credential,
+        df,
+        test_extractor.config.source.abfss_prefix + "/" + test_extractor.config.source.raw_time_series_path
+    )
+
+    unique_external_ids = set()
+    generated_timeseries = []
+    for ts in timeseries_set:
+        if ts["externalId"] not in unique_external_ids:
+            push_time_series_to_cdf([generate_timeseries(ts["externalId"], 1)], cognite_client)
+            generated_timeseries.append(generate_timeseries(ts["externalId"], 1))
+            unique_external_ids.add(ts["externalId"])
+    yield df
+    for ts in generated_timeseries:
+        remove_time_series_data(generated_timeseries, cognite_client)
+
+    remove_time_series_data_from_fabric(
+        azure_credential,
+        test_extractor.config.source.abfss_prefix + "/" + test_extractor.config.source.raw_time_series_path
+    )

--- a/tests/integration/integration_steps/cdf_steps.py
+++ b/tests/integration/integration_steps/cdf_steps.py
@@ -1,10 +1,13 @@
 import pandas as pd
+from pandas import DataFrame
 from datetime import datetime
 from time import sleep
 from cognite.client import CogniteClient
 from cognite.client.data_classes import Datapoint, TimeSeries, TimeSeriesWrite
 from cognite.client.exceptions import CogniteNotFoundError
 from cognite.client.data_classes import DataPointSubscriptionWrite, DatapointSubscription
+
+TIMESTAMP_COLUMN = "timestamp"
 
 def push_data_points_to_cdf(
     external_id: str, data_points: list[Datapoint], cognite_client: CogniteClient
@@ -69,13 +72,6 @@ def update_data_model_in_cdf():
     # Update a data model in CDF
     pass
 
-
-def compare_timestamps(timestamp1: datetime, timestamp2: datetime) -> bool:
-    return timestamp1.replace(microsecond=0) == timestamp2.replace(microsecond=0)
-
-def remove_matching_data_point(data_list: list[Datapoint], timestamp: str, value: str):
-    return [datapoint for datapoint in data_list if compare_timestamps(datapoint.timestamp, timestamp) and datapoint.value != value]
-
 def remove_matching_time_series(time_series_list: list[TimeSeries], external_id: str):
     return [time_series for time_series in time_series_list if time_series.external_id != external_id]
 
@@ -89,34 +85,74 @@ def cdf_timeseries_contain_expected_timeseries(expected_timeseries: list[TimeSer
     )
 
 
-def cdf_datapoints_contain_expected_datapoints(expected_data_list: list[Datapoint], retrieved_data_point_tuple: list[tuple[str, str]]) -> bool:
+def cdf_timeseries_contain_expected_timeseries_ids(
+    expected_timeseries: list[str], retrieved_timeseries_ids: list[str]
+) -> bool:
     return all(
-        any(
-            compare_timestamps(data_point.timestamp, timestamp) and data_point.value == value
-            for timestamp, value in retrieved_data_point_tuple
-        )
-        for data_point in expected_data_list
+        any(ts == retrieved_timeseries_id for retrieved_timeseries_id in retrieved_timeseries_ids)
+        for ts in expected_timeseries
     )
 
 
-def assert_data_points_in_cdf(external_id: str, expected_data_points: list[Datapoint], cognite_client: CogniteClient):
-    result = cognite_client.time_series.data.retrieve_dataframe(external_id=external_id)
-
-    assert cdf_datapoints_contain_expected_datapoints(expected_data_points, [(row[0], row[1][0]) for row in result.iterrows()])
-
-
-def assert_time_series_in_cdf(expected_timeseries: list[TimeSeries], cognite_client: CogniteClient):
+def assert_time_series_in_cdf_by_id(expected_timeseries: list[str], cognite_client: CogniteClient):
     result = cognite_client.time_series.list(limit=-1)
 
-    assert cdf_timeseries_contain_expected_timeseries(expected_timeseries, [ts.external_id for ts in result])
+    assert cdf_timeseries_contain_expected_timeseries_ids(expected_timeseries, [ts.external_id for ts in result])
 
-def remove_time_series_data(list_of_time_series: list[TimeSeries], sub_name: str, cognite_client: CogniteClient):
+
+def compare_timestamps(timestamp1: datetime, timestamp2: datetime) -> bool:
+    timestamp1_str = timestamp1.strftime("%Y-%m-%d %H:%M:%S")
+    timestamp2_str = timestamp2.strftime("%Y-%m-%d %H:%M:%S")
+    return timestamp1_str == timestamp2_str
+
+
+def cdf_datapoints_contain_expected_datapoints(
+    expected_data_list: list[tuple[str, str]], retrieved_data_point_tuple: list[tuple[str, str]]
+) -> bool:
+    return all(
+        any(
+            compare_timestamps(expected_timestamp, timestamp) and expected_value == value
+            for timestamp, value in retrieved_data_point_tuple
+        )
+        for expected_timestamp, expected_value in expected_data_list
+    )
+
+
+def assert_data_points_in_cdf(
+    external_id: str, expected_data_points: list[tuple[str, str]], cognite_client: CogniteClient
+):
+    result = cognite_client.time_series.data.retrieve_dataframe(external_id=external_id)
+
+    result.reset_index(inplace=True)
+    result.rename(columns={"index": "timestamp", external_id: "value"}, inplace=True)
+    result[TIMESTAMP_COLUMN] = pd.to_datetime(result[TIMESTAMP_COLUMN])
+    result[TIMESTAMP_COLUMN] = result[TIMESTAMP_COLUMN].dt.round("s")
+
+    assert cdf_datapoints_contain_expected_datapoints(
+        expected_data_points, [(row.iloc[0], row.iloc[1]) for _, row in result.iterrows()]
+    )
+
+
+def assert_data_points_df_in_cdf(external_id: str, data_points: DataFrame, cognite_client: CogniteClient):
+    data_points_list = []
+    for _, row in data_points.iterrows():
+        data_point = (row.iloc[1], row.iloc[2])
+
+        data_points_list.append(data_point)
+    assert_data_points_in_cdf(
+        external_id=external_id, expected_data_points=data_points_list, cognite_client=cognite_client
+    )
+
+
+def remove_time_series_data(list_of_time_series: list[TimeSeries], cognite_client: CogniteClient):
     for time_series in list_of_time_series:
         try:
             cognite_client.time_series.delete(external_id=time_series.external_id)
         except CogniteNotFoundError:
             print(f'time series {time_series.external_id} not found in CDF')
 
+
+def remove_subscriptions(sub_name: str, cognite_client: CogniteClient):
     try:
         cognite_client.time_series.subscriptions.delete(sub_name)
     except CogniteNotFoundError:

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -1,8 +1,16 @@
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.extractor import CdfFabricExtractor
+from pandas import DataFrame
 
 def run_replicator(test_replicator: TimeSeriesReplicator):
     # Processes data point subscription batches
     test_replicator.process_subscriptions()
+
+
+def run_extractor(test_extractor: CdfFabricExtractor, data_frame: DataFrame):
+    # Processes data point subscription batches
+    test_extractor.write_time_series_to_cdf(data_frame)
+
 
 def start_replicator():
     # Start the replicator service

--- a/tests/integration/integration_steps/time_series_generation.py
+++ b/tests/integration/integration_steps/time_series_generation.py
@@ -45,3 +45,43 @@ def generate_timeseries(external_id: str, num_data_points: int) -> TimeSeries:
     timeseries.datapoints = generate_datapoints(num_points=num_data_points)
 
     return timeseries
+
+
+def generate_raw_timeseries_set(generation_args: TimeSeriesGeneratorArgs) -> list[dict]:
+    flattened_timeseries = []
+    for external_id in generation_args.external_ids:
+        timeseries = generate_raw_timeseries(external_id, generation_args.num_data_points_per_time_series)
+        for datapoint in timeseries["datapoints"]:
+            flattened_timeseries.append({
+                "externalId": external_id,
+                "timestamp": datapoint["timestamp"],
+                "value": datapoint["value"]
+            })
+    return flattened_timeseries
+
+
+def generate_raw_timeseries(external_id: str, num_data_points: int) -> dict:
+    timeseries = {
+        "externalId": external_id,
+        "datapoints": generate_raw_datapoints(num_points=num_data_points),
+    }
+
+    return timeseries
+
+
+def generate_raw_datapoints(num_points: int, days_ago_for_time_range_start=2) -> list[dict]:
+    if num_points <= 0:
+        raise ValueError("Number of data points must be greater than 0")
+    datapoints = []
+    current_time = datetime.now(timezone.utc) - timedelta(days=days_ago_for_time_range_start)
+
+    for _ in range(num_points):
+        data_point = {
+            "timestamp" : current_time,
+            "value" : random.uniform(0, 50)
+        }
+
+        datapoints.append(data_point)
+        current_time += timedelta(seconds=60)
+
+    return datapoints

--- a/tests/integration/test_config.yaml
+++ b/tests/integration/test_config.yaml
@@ -36,3 +36,14 @@ subscriptions:
 data_modeling:
     - space: cc_plant
       lakehouse_abfss_prefix: ${LAKEHOUSE_ABFSS_PREFIX}
+
+source:
+    abfss_prefix: ${LAKEHOUSE_ABFSS_PREFIX}
+    event_path: ${EXTRACTOR_EVENT_PATH}
+    file_path: ${EXTRACTOR_FILE_PATH}
+    raw_time_series_path: ${EXTRAXTOR_RAW_TS_PATH}
+    data_set_id: ${EXTRACTOR_DATASET_ID}
+
+destination:
+    type: ${EXTRACTOR_DESTINATION_TYPE}
+    time_series_prefix: ""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,8 +1,8 @@
 import pytest
-from integration_steps.cdf_steps import push_data_to_cdf
+from integration_steps.cdf_steps import push_data_to_cdf, assert_data_points_df_in_cdf, assert_time_series_in_cdf_by_id
 from integration_steps.time_series_generation import TimeSeriesGeneratorArgs
-from integration_steps.fabric_steps import assert_timeseries_data_in_fabric
-from integration_steps.service_steps import run_replicator
+from integration_steps.fabric_steps import assert_timeseries_data_in_fabric, prepare_test_dataframe_for_comparison
+from integration_steps.service_steps import run_replicator, run_extractor
 
 
 # Test for Timeseries data integration service between CDF and Fabric
@@ -21,3 +21,21 @@ def test_timeseries_data_integration_service(cognite_client, test_replicator, la
     # Assert timeseries data is populated in a Fabric lakehouse
     for ts_external_id, data_points in pushed_data.items():
         assert_timeseries_data_in_fabric(ts_external_id, data_points, lakehouse_timeseries_path, azure_credential)
+
+# Test for Timeseries Extractor service between CDF and Fabric
+@pytest.mark.parametrize(
+    "raw_time_series",
+    [TimeSeriesGeneratorArgs(["int_test_fabcd_hist:mtu:39tic1091.pv"], 10)],
+    indirect=True,
+)
+def test_extractor_timeseries_service(cognite_client, raw_time_series, test_extractor):
+
+    # Run replicator to pick up new timeseries data points in Lakehouse
+    run_extractor(test_extractor, raw_time_series)
+
+    # Assert timeseries data is populated CDF
+    assert_time_series_in_cdf_by_id(raw_time_series["externalId"].unique(), cognite_client)
+
+    for external_id, group in raw_time_series.groupby("externalId"):
+        group = prepare_test_dataframe_for_comparison(group)
+        assert_data_points_df_in_cdf(external_id, group, cognite_client)


### PR DESCRIPTION
Integration Tests for Extractor Service to ingest raw time-series data in fabric to send to CDF.

The Integration Test will accomplish the following:
- Generate and Seed Fabric Tables with Time Series Data
- Run the Extractor 
- Validate that the proper data points were sent and collected within the correct time-series in CDF through the Cognite SDK