### PR TITLE
Integration tests for verifying the state store

### DIFF
--- a/tests/integration/test_config.yaml
+++ b/tests/integration/test_config.yaml
@@ -19,8 +19,9 @@ cognite:
 #Extractor config
 extractor:
     state-store:
-        local:
-            path: states.json
+        raw:
+            database: ${COGNITE_STATE_DB}
+            table: integration_test_state
     subscription-batch-size: 10000
     ingest-batch-size: 100000
     poll-time: 5

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,7 +24,7 @@ def test_timeseries_data_integration_service(cognite_client, test_replicator, la
     # Assert state store is populated in CDF
     assert_state_store_in_cdf(
         test_replicator.config.subscriptions, 
-        test_replicator.config.extractor.state_store.raw.database, 
-        test_replicator.config.extractor.state_store.raw.table, 
+        remote_state_store.database, 
+        remote_state_store.table, 
         cognite_client)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,5 +1,5 @@
 import pytest
-from integration_steps.cdf_steps import push_data_to_cdf
+from integration_steps.cdf_steps import assert_state_store_in_cdf, push_data_to_cdf
 from integration_steps.time_series_generation import TimeSeriesGeneratorArgs
 from integration_steps.fabric_steps import assert_timeseries_data_in_fabric
 from integration_steps.service_steps import run_replicator
@@ -13,7 +13,7 @@ from integration_steps.service_steps import run_replicator
     ],
     indirect=True,
 )
-def test_timeseries_data_integration_service(cognite_client, test_replicator, lakehouse_timeseries_path, time_series, azure_credential):
+def test_timeseries_data_integration_service(cognite_client, test_replicator, lakehouse_timeseries_path, time_series, azure_credential, remote_state_store):
     # Push data points to CDF
     pushed_data = push_data_to_cdf(time_series, cognite_client)
     # Run replicator for data point subscription between CDF and Fabric
@@ -21,3 +21,10 @@ def test_timeseries_data_integration_service(cognite_client, test_replicator, la
     # Assert timeseries data is populated in a Fabric lakehouse
     for ts_external_id, data_points in pushed_data.items():
         assert_timeseries_data_in_fabric(ts_external_id, data_points, lakehouse_timeseries_path, azure_credential)
+    # Assert state store is populated in CDF
+    assert_state_store_in_cdf(
+        test_replicator.config.subscriptions, 
+        test_replicator.config.extractor.state_store.raw.database, 
+        test_replicator.config.extractor.state_store.raw.table, 
+        cognite_client)
+


### PR DESCRIPTION
This PR builds on the existing integration tests of the timeseries data from CDF to Fabric.

It adds the following:
- Fixture to represent the state store, including teardown
- Validation of raw state store data for each time series subscription
- Changes to test_config.yaml to raw state store instead of local state store