### PR TITLE
Data Modeling Executor for Integration Tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ from cognite.extractorutils.base import CancellationToken
 from cognite.extractorutils.metrics import safe_get
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 from dotenv import load_dotenv
 from tests.integration.integration_steps.cdf_steps import remove_time_series_data, push_time_series_to_cdf, create_subscription_in_cdf
 from tests.integration.integration_steps.fabric_steps import get_ts_delta_table
@@ -28,6 +29,22 @@ def test_replicator():
         os.remove("states.json")
     except FileNotFoundError:
         pass
+
+
+@pytest.fixture(scope="function")
+def test_data_modeling_replicator():
+    stop_event = CancellationToken()
+    replicator = DataModelingReplicator(metrics=safe_get(Metrics), stop_event=stop_event)
+    replicator._initial_load_config(override_path=os.environ["TEST_CONFIG_PATH"])
+    replicator.cognite_client = replicator.config.cognite.get_cognite_client(replicator.name)
+    replicator._load_state_store()
+    replicator.logger = Mock()
+    yield replicator
+    try:
+        os.remove("states.json")
+    except FileNotFoundError:
+        pass
+
 
 @pytest.fixture(scope="session")
 def cognite_client():

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -1,8 +1,13 @@
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 
 def run_replicator(test_replicator: TimeSeriesReplicator):
     # Processes data point subscription batches
     test_replicator.process_subscriptions()
+
+def run_data_modeling_replicator(test_data_modeling_replicator: DataModelingReplicator):
+    # Processes data point subscription batches
+    test_data_modeling_replicator.process_spaces()
 
 def start_replicator():
     # Start the replicator service

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -6,7 +6,7 @@ def run_replicator(test_replicator: TimeSeriesReplicator):
     test_replicator.process_subscriptions()
 
 def run_data_modeling_replicator(test_data_modeling_replicator: DataModelingReplicator):
-    # Processes data point subscription batches
+    # Processes spaces for data-modeling changes
     test_data_modeling_replicator.process_spaces()
 
 def start_replicator():


### PR DESCRIPTION
Added a Data Modeling Fixture that allows integration tests to run a configurable instance of `DataModelingReplicator` for validations. 

This allows the integration tests to ensure that the changes in CDF are reflected within the Fabric Lakehouse Tables, view the screenshots below that demonstrate this capability:

**Running the Tests**
![image](https://github.com/cognitedata/cdf-fabric-replicator/assets/50754008/46379ada-68f2-484c-b339-31e099671a41)

**Make a Change in CDF (This is an example through the CDF Portal)**
<img width="1416" alt="image" src="https://github.com/cognitedata/cdf-fabric-replicator/assets/50754008/1544b8f4-e63f-4bff-9e8c-3e9e07249324">

**Validate Change Was Reflected in Lakehouse**
<img width="1036" alt="image" src="https://github.com/cognitedata/cdf-fabric-replicator/assets/50754008/d5e16efc-c1bf-4876-a323-4ddb72e87e07">
