### PR TITLE
Fix bug where time series replicator parquet output missing timezone

### DIFF
--- a/cdf_fabric_replicator/time_series.py
+++ b/cdf_fabric_replicator/time_series.py
@@ -149,7 +149,7 @@ class TimeSeriesReplicator(Extractor):
             for i in range(0, len(update.upserts.timestamp)):
                 rows.append( 
                     (update.upserts.external_id, 
-                    datetime.datetime.fromtimestamp(update.upserts.timestamp[i]/1000), 
+                    pd.to_datetime(update.upserts.timestamp[i], unit='ms', utc=True),
                     update.upserts.value[i]) )
         if len(rows) == 0:
             logging.info ("No data in updates list.")

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -34,8 +34,8 @@ class TestTimeSeriesReplicator():
 
     def test_convert_updates_to_pandasdf_when_not_null(self, input_data_not_null):
         pd_df = pd.DataFrame(data=[
-            ["id1", datetime.datetime.fromtimestamp(1631234567), 1.23],
-            ["id1", datetime.datetime.fromtimestamp(1631234568), 4.56]],
+            ["id1", pd.to_datetime(1631234567, unit='s', utc=True), 1.23],
+            ["id1", pd.to_datetime(1631234568, unit='s', utc=True), 4.56]],
             columns=["externalId", "timestamp", "value"])
 
         df = self.replicator.convert_updates_to_pandasdf(input_data_not_null)


### PR DESCRIPTION
This PR adds timezone context to the Pandas dataframe to fix the following bug:

When writing timeseries data to a parquet file in a Fabric Lakehouse, the time series replicator fails to set a timezone on the timestamp column. The result is that Fabric Data Pipeline and Fabric Data Flow cannot parse the timestamp column, resulting in the following error:

> The data type is not supported in Delta format. Reason: Cannot find supported logical type for column name timestamp, delta type timestamp_ntz Activity ID: 6dfdd3a8-4572-47c8-b4db-9c684e3ba8b0