### PR TITLE
Fix Flakiness of Integration Test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ from cognite.extractorutils.base import CancellationToken
 from cognite.extractorutils.metrics import safe_get
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 from dotenv import load_dotenv
 from tests.integration.integration_steps.cdf_steps import remove_time_series_data, push_time_series_to_cdf, create_subscription_in_cdf
 from tests.integration.integration_steps.fabric_steps import get_ts_delta_table
@@ -28,6 +29,22 @@ def test_replicator():
         os.remove("states.json")
     except FileNotFoundError:
         pass
+
+
+@pytest.fixture(scope="function")
+def test_data_modeling_replicator():
+    stop_event = CancellationToken()
+    replicator = DataModelingReplicator(metrics=safe_get(Metrics), stop_event=stop_event)
+    replicator._initial_load_config(override_path=os.environ["TEST_CONFIG_PATH"])
+    replicator.cognite_client = replicator.config.cognite.get_cognite_client(replicator.name)
+    replicator._load_state_store()
+    replicator.logger = Mock()
+    yield replicator
+    try:
+        os.remove("states.json")
+    except FileNotFoundError:
+        pass
+
 
 @pytest.fixture(scope="session")
 def cognite_client():

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -1,8 +1,13 @@
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
+from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 
 def run_replicator(test_replicator: TimeSeriesReplicator):
     # Processes data point subscription batches
     test_replicator.process_subscriptions()
+
+def run_data_modeling_replicator(test_data_modeling_replicator: DataModelingReplicator):
+    # Processes data point subscription batches
+    test_data_modeling_replicator.process_spaces()
 
 def start_replicator():
     # Start the replicator service

--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -6,7 +6,7 @@ def run_replicator(test_replicator: TimeSeriesReplicator):
     test_replicator.process_subscriptions()
 
 def run_data_modeling_replicator(test_data_modeling_replicator: DataModelingReplicator):
-    # Processes data point subscription batches
+    # Processes spaces for data-modeling changes
     test_data_modeling_replicator.process_spaces()
 
 def start_replicator():


### PR DESCRIPTION
Added several changes to address flaky timeseries replicator test:

  *  Changed external id for extractor test to be different from time series replicator test
  *  Added deletion of Lakehouse table data to fixture setup
  *  Deleted code to localize time zone for Lakehouse dataframe as 

https://github.com/cognitedata/cdf-fabric-replicator/pull/49 fixed issue of Lakehouse dataframes being timezone naive
As a follow up item, we should generate external id's per test run to prevent race conditions from concurrent test runs.