### PR TITLE
Runtime Error: Threading Fix for multiple workers

### DIFF
--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -35,6 +35,8 @@ def main() -> None:
 
     for worker in worker_list:
         worker.start()
+
+    for worker in worker_list:
         worker.join()
 
 if __name__ == "__main__":

--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -18,30 +18,23 @@ def main() -> None:
     with EventsReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as event_replicator:
-        event_worker = threading.Thread(target=event_replicator.run)
-        event_worker.start()
-        worker_list.append(event_worker)
-        
+        worker_list.append(threading.Thread(target=event_replicator.run))
+
     with TimeSeriesReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as ts_replicator:
-        ts_worker = threading.Thread(target=ts_replicator.run)
-        ts_worker.start()
-        worker_list.append(ts_worker)
-        
+        worker_list.append(threading.Thread(target=ts_replicator.run))
+
     with CdfFabricExtractor(stop_event=stop_event) as extractor:
-        extractor_worker = threading.Thread(target=extractor.run)
-        extractor_worker.start()
-        worker_list.append(extractor_worker)
+        worker_list.append(threading.Thread(target=extractor.run))
 
     with DataModelingReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as dm_replicator:
-        dm_worker = threading.Thread(target=dm_replicator.run)
-        dm_worker.start()
-        worker_list.append(dm_worker)
+        worker_list.append(threading.Thread(target=dm_replicator.run))
 
     for worker in worker_list:
+        worker.start()
         worker.join()
 
 if __name__ == "__main__":

--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -13,30 +13,36 @@ import threading
 
 def main() -> None:
     stop_event = CancellationToken()
+    worker_list = []
 
     with EventsReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as event_replicator:
         event_worker = threading.Thread(target=event_replicator.run)
         event_worker.start()
-
+        worker_list.append(event_worker)
+        
     with TimeSeriesReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as ts_replicator:
         ts_worker = threading.Thread(target=ts_replicator.run)
         ts_worker.start()
-
+        worker_list.append(ts_worker)
+        
     with CdfFabricExtractor(stop_event=stop_event) as extractor:
         extractor_worker = threading.Thread(target=extractor.run)
         extractor_worker.start()
+        worker_list.append(extractor_worker)
 
     with DataModelingReplicator(
         metrics=safe_get(Metrics), stop_event=stop_event
     ) as dm_replicator:
         dm_worker = threading.Thread(target=dm_replicator.run)
         dm_worker.start()
-        dm_worker.join()
+        worker_list.append(dm_worker)
 
+    for worker in worker_list:
+        worker.join()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# PR Description
This is a fix for a threading issue that wasn't waiting on single workers when started up due to the main worker being shut down. 

This solution will essentially `wait all` on every worker we create to ensure that the main thread is alive for execution and not shut down until all worker threads are signaled to exit or stop.