### PR TITLE
Added launch.json for VSCode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "poetry install",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "poetry",
+            "args": [
+                "-vvv",  // change or comment out for different verbosity level
+                "install"
+            ],
+        },
+        {
+            "name": "poetry run",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "poetry",
+            "args": [
+                "-vvv",  // change or comment out for different verbosity level
+                "run",
+                "cdf_fabric_replicator",
+                "example_config.yaml"
+            ],
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ To run the `cdf_fabric_replicator` application, you can use Poetry, a dependency
 
 First, make sure you have Poetry installed on your system. If not, you can install it by following the instructions in the [Poetry documentation](https://python-poetry.org/docs/#installation).
 
+## Command-line
+
 Once Poetry is installed, navigate to the root directory of your project in your terminal.
 
 Next, run the following command to install the project dependencies:
@@ -166,3 +168,14 @@ Finally, run the replicator:
 ```
 poetry run cdf_fabric_replicator config.yaml
 ```
+
+## Visual Studio Code
+
+Alternatively, if you are using Visual Studio Code, just open the folder of the root directory of your project.
+
+You must still install Poetry as mentioned above in addition to the [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for VSCode.
+
+The included ".vscode/launch.json" file will add "poetry install" and "poetry run" to your "Run and Debug" tab. They can be used in place of the manual command line statements above, and will attach the VSCode debugger.
+
+For more information see [Debugging in Visual Studio Code](https://code.visualstudio.com/Docs/editor/debugging).
+


### PR DESCRIPTION
This pull request primarily focuses on improving the developer experience by providing additional ways to run and debug the `cdf_fabric_replicator` application. It includes the addition of a Visual Studio Code configuration file and updates to the `README.md` file to explain how to use it.

The most important changes are:

* `.vscode/launch.json`: A new configuration file for Visual Studio Code has been added. This file includes two configurations: one for installing project dependencies using Poetry, and another for running the `cdf_fabric_replicator` application with specific arguments. This allows developers to run and debug the application directly from Visual Studio Code.

Updates to the `README.md`:

* `README.md`: Additional instructions have been provided for developers using Visual Studio Code. This includes information on necessary extensions and how to use the newly added `.vscode/launch.json` configurations.