### PR TITLE
added required gcc install to docker file

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH /root/.local/bin:$PATH
 RUN apt update
 RUN apt install -y curl
 RUN apt install -y less
+RUN apt-get install -y gcc
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 RUN mkdir -p cdf_fabric_replicator 


### PR DESCRIPTION
# Docker File Fix

This will fix the current docker file build by adding the required gcc package when installing through the pip command for psutil as seen here:

<img width="1270" alt="image" src="https://github.com/cognitedata/cdf-fabric-replicator/assets/50754008/d763de96-6bcc-414b-98ad-af4dc0d08c8d">
