### PR TITLE
Add fabric assertions for data model replicator integration tests

### DIFF
--- a/tests/integration/integration_steps/service_steps.py
+++ b/tests/integration/integration_steps/service_steps.py
@@ -1,7 +1,6 @@
 from cdf_fabric_replicator.time_series import TimeSeriesReplicator
 from cdf_fabric_replicator.extractor import CdfFabricExtractor
 from pandas import DataFrame
-from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 
 
 def run_replicator(test_replicator: TimeSeriesReplicator):
@@ -14,11 +13,6 @@ def run_extractor(test_extractor: CdfFabricExtractor, data_frame: DataFrame):
     test_extractor.write_time_series_to_cdf(data_frame)
 
 
-def run_data_modeling_replicator(test_data_modeling_replicator: DataModelingReplicator):
-    # Processes spaces for data-modeling changes
-    test_data_modeling_replicator.process_spaces()
-
-
 def start_replicator():
     # Start the replicator service
     pass
@@ -26,9 +20,4 @@ def start_replicator():
 
 def stop_replicator():
     # Stop the replicator service
-    pass
-
-
-def run_data_model_sync():
-    # Run data model sync service between CDF and Fabric
     pass

--- a/tests/integration/test_data_model_replicator.py
+++ b/tests/integration/test_data_model_replicator.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import pandas as pd
 from unittest.mock import Mock
 from azure.identity import DefaultAzureCredential
 from cognite.client import CogniteClient
@@ -13,12 +14,11 @@ from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 from tests.integration.integration_steps.cdf_steps import (
     apply_data_model_instances_in_cdf,
 )
-from tests.integration.integration_steps.service_steps import run_data_model_sync
 from tests.integration.integration_steps.fabric_steps import (
     delete_delta_table_data,
     lakehouse_table_name,
-    assert_data_model_in_fabric,
-    assert_data_model_update,
+    assert_data_model_instances_in_fabric,
+    assert_data_model_instances_update,
 )
 from integration_steps.data_model_generation import Node, Edge, create_node, create_edge
 
@@ -109,6 +109,8 @@ def instance_table_paths(
             lakehouse_table_name(test_model.space + "_" + view.external_id)
         )
         delete_delta_table_data(azure_credential, instance_table_paths[-1])
+    edge_table_path = lakehouse_table_name(test_model.space + "_edges")
+    instance_table_paths.append(edge_table_path)
     yield instance_table_paths
     for path in instance_table_paths:
         delete_delta_table_data(azure_credential, path)
@@ -210,31 +212,109 @@ def edge_list(
     )
 
 
+def node_info_dict(node: Node, space: str, type: str, version: int = 1) -> dict:
+    return {
+        "space": space,
+        "instanceType": "node",
+        "externalId": node.external_id,
+        "version": version,
+        **node.source_dict[type],
+    }
+
+
+def edge_info_dict(edge: Edge, space: str) -> dict:
+    return {
+        "space": space,
+        "instanceType": "edge",
+        "externalId": edge.external_id,
+        "version": 1,
+        "startNode": {"space": space, "externalId": edge.start_node.external_id},
+        "endNode": {"space": space, "externalId": edge.end_node.external_id},
+    }
+
+
+@pytest.fixture(scope="function")
+def instance_dataframes(
+    example_actor: Node,
+    example_movie: Node,
+    example_edge_actor_to_movie: Edge,
+    example_edge_movie_to_actor: Edge,
+    test_space: Space,
+) -> dict[str, pd.DataFrame]:
+    actor_dataframe = pd.DataFrame(
+        node_info_dict(example_actor, test_space.space, "Actor"), index=[0]
+    )
+    person_dataframe = pd.DataFrame(
+        node_info_dict(example_actor, test_space.space, "Person"), index=[0]
+    )
+    movie_dataframe = pd.DataFrame(
+        node_info_dict(example_movie, test_space.space, "Movie"), index=[0]
+    )
+    edge_dataframe = pd.DataFrame(
+        [
+            edge_info_dict(example_edge_actor_to_movie, test_space.space),
+            edge_info_dict(example_edge_movie_to_actor, test_space.space),
+        ],
+        index=pd.RangeIndex(start=0, stop=2, step=1),
+    )
+    return {
+        test_space.space + "_Actor": actor_dataframe,
+        test_space.space + "_Person": person_dataframe,
+        test_space.space + "_Movie": movie_dataframe,
+        test_space.space + "_edges": edge_dataframe,
+    }
+
+
+@pytest.fixture(scope="function")
+def update_dataframe(
+    example_actor: Node, updated_actor: Node, test_space: Space
+) -> tuple[str, pd.DataFrame]:
+    return (
+        test_space.space + "_Actor",
+        pd.DataFrame(
+            [
+                node_info_dict(updated_actor, test_space.space, "Actor", 2),
+                node_info_dict(example_actor, test_space.space, "Actor"),
+            ],
+            index=pd.RangeIndex(start=0, stop=2, step=1),
+        ),
+    )
+
+
 # Test for data model sync service
 def test_data_model_sync_service_creation(
-    edge_table_path, instance_table_paths, node_list, edge_list, cognite_client
+    test_data_modeling_replicator,
+    instance_table_paths,
+    node_list,
+    edge_list,
+    instance_dataframes,
+    cognite_client,
+    azure_credential,
 ):
     # Create a data model in CDF
     apply_data_model_instances_in_cdf(node_list, edge_list, cognite_client)
     # Run data model sync service between CDF and Fabric
-    run_data_model_sync()
+    test_data_modeling_replicator.process_spaces()
     # Assert the data model is populated in a Fabric lakehouse
-    assert_data_model_in_fabric()
+    assert_data_model_instances_in_fabric(
+        instance_table_paths, instance_dataframes, azure_credential
+    )
 
 
 def test_data_model_sync_service_update(
+    test_data_modeling_replicator,
     updated_node_list,
-    edge_table_path,
-    instance_table_paths,
     node_list,
     edge_list,
+    update_dataframe,
     cognite_client,
+    azure_credential,
 ):
     # Apply instances and run data model sync service between CDF and Fabric
     apply_data_model_instances_in_cdf(node_list, edge_list, cognite_client)
-    run_data_model_sync()
+    test_data_modeling_replicator.process_spaces()
     # Update instances in CDF and run data model sync
     apply_data_model_instances_in_cdf(updated_node_list, [], cognite_client)
-    run_data_model_sync()
-    # Assert the data model changes including versions and last updated timestamps are propagated to a Fabric lakehouse
-    assert_data_model_update()
+    test_data_modeling_replicator.process_spaces()
+    # Assert the data model changes including versions are propagated to a Fabric lakehouse
+    assert_data_model_instances_update(update_dataframe, azure_credential)


### PR DESCRIPTION
Adds steps to the data model replicator integration tests to run the data model replicator and assert that the Fabric data matches the expected values and schema.