### PR TITLE
Fabric Extractor File Upload Integration Test

### DIFF
--- a/tests/integration/integration_steps/cdf_steps.py
+++ b/tests/integration/integration_steps/cdf_steps.py
@@ -335,10 +335,17 @@ def remove_events_from_cdf(cognite_client: CogniteClient, events: List[EventWrit
     )
 
 
-def assert_file_in_cdf(cognite_client: CogniteClient, file_name: str, retries: int):
+def assert_file_in_cdf(
+    cognite_client: CogniteClient,
+    file_name: str,
+    abfss_prefix: str,
+    file_path: str,
+    retries: int,
+):
+    file_external_id = "/" + abfss_prefix.split("/")[-1] + f"/{file_path}/" + file_name
     for _ in range(retries):
-        res = cognite_client.files.search(name=file_name)
-        if len(res.data) == 1:
+        res = cognite_client.files.retrieve(external_id=file_external_id)
+        if res is not None:
             print("File found in CDF")
             return True
         print(f"File not found in CDF, retrying...(attempt {_+1}/{retries})")
@@ -346,8 +353,11 @@ def assert_file_in_cdf(cognite_client: CogniteClient, file_name: str, retries: i
     return False
 
 
-def remove_file_from_cdf(cognite_client: CogniteClient, file_name: str):
-    res = cognite_client.files.search(name=file_name)
-    if len(res.data) == 1:
-        return cognite_client.files.delete(id=res.data[0].id)
+def remove_file_from_cdf(
+    cognite_client: CogniteClient, file_name: str, abfss_prefix: str, file_path: str
+):
+    file_external_id = "/" + abfss_prefix.split("/")[-1] + f"/{file_path}/" + file_name
+    res = cognite_client.files.retrieve(external_id=file_external_id)
+    if res is not None:
+        return cognite_client.files.delete(external_id=file_external_id)
     return None

--- a/tests/integration/integration_steps/cdf_steps.py
+++ b/tests/integration/integration_steps/cdf_steps.py
@@ -254,7 +254,7 @@ def delete_state_store_in_cdf(
             if row is not None:
                 cognite_client.raw.rows.delete(database, table, statename)
 
-    all_rows = cognite_client.raw.rows.list(database, table, limit=1)
+    all_rows = cognite_client.raw.rows.list(database, table)
     for row in all_rows:
         cognite_client.raw.rows.delete(database, table, row.key)
 
@@ -333,3 +333,21 @@ def remove_events_from_cdf(cognite_client: CogniteClient, events: List[EventWrit
     return cognite_client.events.delete(
         external_id=event_external_ids, ignore_unknown_ids=True
     )
+
+
+def assert_file_in_cdf(cognite_client: CogniteClient, file_name: str, retries: int):
+    for _ in range(retries):
+        res = cognite_client.files.search(name=file_name)
+        if len(res.data) == 1:
+            print("File found in CDF")
+            return True
+        print(f"File not found in CDF, retrying...(attempt {_+1}/{retries})")
+        sleep(2**_)  # wait before the next retry using exponential backoff
+    return False
+
+
+def remove_file_from_cdf(cognite_client: CogniteClient, file_name: str):
+    res = cognite_client.files.search(name=file_name)
+    if len(res.data) == 1:
+        return cognite_client.files.delete(id=res.data[0].id)
+    return None

--- a/tests/integration/integration_steps/fabric_steps.py
+++ b/tests/integration/integration_steps/fabric_steps.py
@@ -168,7 +168,9 @@ def parse_abfss_url(url: str) -> tuple[str, str, str]:
     parsed_url = urlparse(url)
 
     if "@" not in parsed_url.netloc or "." not in parsed_url.netloc:
-        raise ValueError("URL is not in the expected format.  Expected format is abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>")
+        raise ValueError(
+            "URL is not in the expected format.  Expected format is abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>"
+        )
 
     container_id = parsed_url.netloc.split("@")[0]
     account_name = parsed_url.netloc.split("@")[1].split(".")[0]

--- a/tests/integration/integration_steps/fabric_steps.py
+++ b/tests/integration/integration_steps/fabric_steps.py
@@ -167,6 +167,9 @@ def assert_events_data_in_fabric(
 def parse_abfss_url(url: str) -> tuple[str, str, str]:
     parsed_url = urlparse(url)
 
+    if "@" not in parsed_url.netloc or "." not in parsed_url.netloc:
+        raise ValueError("URL is not in the expected format.  Expected format is abfss://<workspace>@onelake.dfs.fabric.microsoft.com/<lakehouse>")
+
     container_id = parsed_url.netloc.split("@")[0]
     account_name = parsed_url.netloc.split("@")[1].split(".")[0]
     file_path = parsed_url.path

--- a/tests/integration/test_data_model_replicator.py
+++ b/tests/integration/test_data_model_replicator.py
@@ -43,6 +43,7 @@ def test_data_modeling_replicator():
     except FileNotFoundError:
         pass
 
+
 @pytest.fixture(scope="session")
 def test_space(test_config, cognite_client: CogniteClient):
     space_id = test_config["data_modeling"][0]["space"]
@@ -64,7 +65,11 @@ def test_space(test_config, cognite_client: CogniteClient):
 
 
 @pytest.fixture(scope="function")
-def test_model(cognite_client: CogniteClient, test_space: Space, test_data_modeling_replicator: DataModelingReplicator):
+def test_model(
+    cognite_client: CogniteClient,
+    test_space: Space,
+    test_data_modeling_replicator: DataModelingReplicator,
+):
     test_dml = (RESOURCES / "movie_model.graphql").read_text()
     movie_id = DataModelId(space=test_space.space, external_id="Movie", version="1")
     created = cognite_client.data_modeling.graphql.apply_dml(
@@ -88,8 +93,12 @@ def test_model(cognite_client: CogniteClient, test_space: Space, test_data_model
         cognite_client.data_modeling.containers.delete(
             (test_space.space, view.external_id)
         )
-        test_data_modeling_replicator.state_store.delete_state(f"state_{test_space.space}_{view.external_id}_{view.version}")
-    test_data_modeling_replicator.state_store.delete_state(f"state_{test_space.space}_edges")
+        test_data_modeling_replicator.state_store.delete_state(
+            f"state_{test_space.space}_{view.external_id}_{view.version}"
+        )
+    test_data_modeling_replicator.state_store.delete_state(
+        f"state_{test_space.space}_edges"
+    )
     test_data_modeling_replicator.state_store.synchronize()
 
 

--- a/tests/integration/test_data_model_replicator.py
+++ b/tests/integration/test_data_model_replicator.py
@@ -13,6 +13,7 @@ from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 from tests.integration.integration_steps.cdf_steps import (
     apply_data_model_instances_in_cdf,
+    delete_state_store_in_cdf,
 )
 from tests.integration.integration_steps.fabric_steps import (
     delete_delta_table_data,
@@ -42,6 +43,12 @@ def test_data_modeling_replicator():
         os.remove("states.json")
     except FileNotFoundError:
         pass
+    delete_state_store_in_cdf(
+        replicator.config.subscriptions,
+        replicator.config.extractor.state_store.raw.database,
+        replicator.config.extractor.state_store.raw.table,
+        replicator.cognite_client,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -303,6 +310,7 @@ def test_data_model_sync_service_creation(
 
 def test_data_model_sync_service_update(
     test_data_modeling_replicator,
+    instance_table_paths,
     updated_node_list,
     node_list,
     edge_list,

--- a/tests/integration/test_fabric_extractor.py
+++ b/tests/integration/test_fabric_extractor.py
@@ -112,7 +112,12 @@ def test_csv_file_path(test_extractor, azure_credential, cognite_client):
         test_extractor.config.source.file_path,
         azure_credential,
     )
-    remove_file_from_cdf(cognite_client, TEST_FILE_NAME)
+    remove_file_from_cdf(
+        cognite_client,
+        TEST_FILE_NAME,
+        test_extractor.config.source.abfss_prefix,
+        test_extractor.config.source.file_path,
+    )
 
 
 # Test for Timeseries Extractor service between CDF and Fabric
@@ -158,4 +163,10 @@ def test_extractor_abfss_file_upload(
     )
 
     # Assert that the file is available in CDF
-    assert assert_file_in_cdf(cognite_client, TEST_FILE_NAME, CDF_RETRIES)
+    assert assert_file_in_cdf(
+        cognite_client,
+        TEST_FILE_NAME,
+        test_extractor.config.source.abfss_prefix,
+        test_extractor.config.source.file_path,
+        CDF_RETRIES,
+    )


### PR DESCRIPTION
This PR adds an integration test for scenario where files in Lakehouse are uploaded via the Fabric extractor.
## Code Changes

- Adds integration test `test_extractor_abfss_file_upload`.  This test:
   1. Creates and uploads a test CSV file to the integration test Lakehouse's Files storage
   1. Runs the extractor method `upload_files_from_abfss` to add the file to CDF
   1. Asserts the file is in CDF (with a retry mechanism) 

Additionally, there are fixes for flakiness caused by inconsistencies in fixture cleanup introduced in the data model replicator tests:
- Cleanup of delta tables added for `test_data_model_sync_service_update`
- Deletion of state store in test data model replicator cleanup