### PR TITLE
Data Model Replicator Unit Tests

### DIFF
--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -13,6 +13,7 @@ from cdf_fabric_replicator.event import EventsReplicator
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.log_config import LOGGING_CONFIG
 
+
 def main() -> None:
     logging.config.dictConfig(LOGGING_CONFIG)
     logging.info("Starting CDF Fabric Replicator")

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -39,7 +39,7 @@ class DataModelingReplicator(Extractor):
             cancellation_token=stop_event,
         )
         self.metrics: Metrics
-        # self.stop_event = stop_event
+        self.stop_event = stop_event
         self.endpoint_source_map: Dict[str, Any] = {}
         self.errors: List[str] = []
         self.azure_credential = DefaultAzureCredential()
@@ -52,7 +52,7 @@ class DataModelingReplicator(Extractor):
             logging.info("No data modeling spaces found in config")
             return
 
-        while True:  # not self.stop_event.is_set():
+        while not self.stop_event.is_set():
             start_time = time.time()  # Get the current time in seconds
 
             self.process_spaces()

--- a/tests/unit/test_data_modeling.py
+++ b/tests/unit/test_data_modeling.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch, Mock
 
 from collections import UserDict
+import pyarrow as pa
 
 from cdf_fabric_replicator.data_modeling import DataModelingReplicator
 from cdf_fabric_replicator.config import Config, DataModelingConfig
@@ -9,13 +11,111 @@ from cognite.client.data_classes.data_modeling.instances import Node, Edge
 from cognite.client.data_classes.data_modeling import DirectRelationReference
 from cognite.client.data_classes.data_modeling.ids import ViewId
 from cognite.client.data_classes.data_modeling.query import (
+    Query,
     QueryResult,
     NodeListWithCursor,
     EdgeListWithCursor,
+    Select,
+    SourceSelector,
+    NodeResultSetExpression,
+    EdgeResultSetExpression,
 )
+from cognite.client.data_classes.filters import HasData, Equals
 
-from cognite.extractorutils.metrics import BaseMetrics
-from cognite.extractorutils.base import CancellationToken
+
+@pytest.fixture
+def test_data_modeling_replicator():
+    replicator = DataModelingReplicator(metrics=Mock(), stop_event=Mock())
+    replicator.cognite_client = Mock()
+    replicator.config = Mock()
+    replicator.state_store = Mock()
+    yield replicator
+
+
+@pytest.fixture
+def mock_data_modeling_config():
+    yield DataModelingConfig(
+        space="test_space", lakehouse_abfss_prefix="test_abfss_prefix"
+    )
+
+
+@pytest.fixture
+def node_view_query():
+    yield Query(
+        with_={
+            "nodes": NodeResultSetExpression(
+                filter=HasData(
+                    views=[
+                        ViewId(
+                            space="test_space",
+                            external_id="test_id",
+                            version="test_version",
+                        )
+                    ]
+                )
+            )
+        },
+        select={
+            "nodes": Select(
+                [
+                    SourceSelector(
+                        source=ViewId(
+                            space="test_space",
+                            external_id="test_id",
+                            version="test_version",
+                        ),
+                        properties=["prop1", "prop2"],
+                    )
+                ]
+            )
+        },
+    )
+
+
+@pytest.fixture
+def edge_view_query():
+    yield Query(
+        with_={
+            "edges": EdgeResultSetExpression(
+                filter=Equals(
+                    ["edge", "type"], {"space": "test_space", "externalId": "test_id"}
+                )
+            )
+        },
+        select={
+            "edges": Select(
+                [
+                    SourceSelector(
+                        source=ViewId(
+                            space="test_space",
+                            external_id="test_id",
+                            version="test_version",
+                        ),
+                        properties=["prop1", "prop2"],
+                    )
+                ]
+            )
+        },
+    )
+
+
+@pytest.fixture
+def edge_query():
+    yield Query(
+        with_={"edges": EdgeResultSetExpression()},
+        select={"edges": Select()},
+    )
+
+
+@pytest.fixture
+def mock_view():
+    yield {
+        "space": "test_space",
+        "externalId": "test_id",
+        "version": "test_version",
+        "usedFor": "node",
+        "properties": {"prop1": "value1", "prop2": "value2"},
+    }
 
 
 @pytest.fixture
@@ -200,7 +300,7 @@ def lakehouse_abfss_prefix():
 
 
 @pytest.fixture
-def replicator_config(lakehouse_abfss_prefix):
+def replicator_config(mock_data_modeling_config):
     yield Config(
         type=None,
         cognite=None,
@@ -209,38 +309,250 @@ def replicator_config(lakehouse_abfss_prefix):
         extractor=None,
         subscriptions=None,
         event=None,
-        data_modeling=DataModelingConfig(
-            space="test_space", lakehouse_abfss_prefix=lakehouse_abfss_prefix
-        ),
+        data_modeling=mock_data_modeling_config,
         source=None,
         destination=None,
     )
 
 
 class TestDataModelingReplicator:
-    metrics = BaseMetrics(
-        extractor_name="test_dm_duplicator", extractor_version="1.0.0"
-    )
-    replicator = DataModelingReplicator(metrics=metrics, stop_event=CancellationToken())
+    def test_run(self, mock_data_modeling_config, test_data_modeling_replicator):
+        # Mock the stop_event.is_set response to only run replicator once
+        test_data_modeling_replicator.stop_event.is_set.side_effect = [
+            False,
+            True,
+        ]
+        # Mock the config
+        test_data_modeling_replicator.config = Mock(
+            data_modeling=[mock_data_modeling_config], extractor=Mock(poll_time=1)
+        )
+        # Mock the process_spaces method since it's not the focus of this test
+        test_data_modeling_replicator.process_spaces = Mock()
+        # Call the method under test
+        test_data_modeling_replicator.run()
+        # Asssert that the process_spaces method was called
+        test_data_modeling_replicator.process_spaces.assert_called_once()
 
-    def test_get_instances_null(self, query_result_empty):
-        instances = self.replicator.get_instances(query_result_empty, is_edge=False)
+    def test_run_no_data_modeling(self, test_data_modeling_replicator):
+        # Mock the config
+        test_data_modeling_replicator.config = Mock(
+            data_modeling=None, extractor=Mock(poll_time=1)
+        )
+        # Mock the process_spaces method to assert not called
+        test_data_modeling_replicator.process_spaces = Mock()
+        # Call the method under test
+        test_data_modeling_replicator.run()
+        # Asssert that the process_spaces method was not called
+        test_data_modeling_replicator.process_spaces.assert_not_called()
+
+    def test_process_spaces(
+        self, mock_data_modeling_config, test_data_modeling_replicator
+    ):
+        # Mock the data_modeling config
+        test_data_modeling_replicator.config.data_modeling = [mock_data_modeling_config]
+
+        # Mock the views.list response
+        test_data_modeling_replicator.cognite_client.data_modeling.views.list.return_value = Mock(
+            dump=Mock(
+                return_value=[{"externalId": "test_id", "version": "test_version"}]
+            )
+        )
+
+        # Mock the process_instances method since it's not the focus of this test
+        test_data_modeling_replicator.process_instances = Mock()
+
+        # Call the method under test
+        test_data_modeling_replicator.process_spaces()
+
+        # Assert that the process_instances method was called with the expected arguments
+        test_data_modeling_replicator.process_instances.assert_any_call(
+            mock_data_modeling_config,
+            "state_test_space_test_id_test_version",
+            {"externalId": "test_id", "version": "test_version"},
+        )
+        test_data_modeling_replicator.process_instances.assert_any_call(
+            mock_data_modeling_config, "state_test_space_edges"
+        )
+
+    def test_process_instances_with_view(
+        self, mock_data_modeling_config, mock_view, test_data_modeling_replicator
+    ):
+        # Mock the generate_query responses
+        test_data_modeling_replicator.generate_query_based_on_view = Mock(
+            return_value="test_query"
+        )
+        test_data_modeling_replicator.generate_query_based_on_edge = Mock()
+
+        # Mock the write_instance_to_lakehouse method
+        test_data_modeling_replicator.write_instance_to_lakehouse = Mock()
+
+        # Call the method under test
+        test_data_modeling_replicator.process_instances(
+            mock_data_modeling_config,
+            "state_test_space_test_id_test_version",
+            mock_view,
+        )
+
+        # Assert that the generate_query_based_on_view method was called with the expected arguments
+        test_data_modeling_replicator.generate_query_based_on_view.assert_called_once_with(
+            mock_view
+        )
+
+        # Assert that the write_instance_to_lakehouse method was called with the expected arguments
+        test_data_modeling_replicator.write_instance_to_lakehouse.assert_called_once_with(
+            mock_data_modeling_config,
+            "state_test_space_test_id_test_version",
+            "test_query",
+        )
+
+        # Assert that the generate_query_based_on_edge method was not called
+        test_data_modeling_replicator.generate_query_based_on_edge.assert_not_called()
+
+    def test_process_instances_with_edge(
+        self, mock_data_modeling_config, test_data_modeling_replicator
+    ):
+        # Mock the generate_query responses
+        test_data_modeling_replicator.generate_query_based_on_view = Mock()
+        test_data_modeling_replicator.generate_query_based_on_edge = Mock(
+            return_value="test_query"
+        )
+
+        # Mock the write_instance_to_lakehouse method
+        test_data_modeling_replicator.write_instance_to_lakehouse = Mock()
+
+        # Call the method under test
+        test_data_modeling_replicator.process_instances(
+            mock_data_modeling_config, "state_test_space_edges"
+        )
+
+        # Assert that the generate_query_based_on_view method was not called
+        test_data_modeling_replicator.generate_query_based_on_view.assert_not_called()
+
+        # Assert that the write_instance_to_lakehouse method was called with the expected arguments
+        test_data_modeling_replicator.write_instance_to_lakehouse.assert_called_once_with(
+            mock_data_modeling_config, "state_test_space_edges", "test_query"
+        )
+
+        # Assert that the generate_query_based_on_edge method was called
+        test_data_modeling_replicator.generate_query_based_on_edge.assert_called_once()
+
+    def test_generate_query_based_on_view_node(
+        self, node_view_query, mock_view, test_data_modeling_replicator
+    ):
+        # Call the method under test
+        result_query = test_data_modeling_replicator.generate_query_based_on_view(
+            mock_view
+        )
+
+        # Assert that the query is as expected
+        assert result_query == node_view_query
+
+    def test_generate_query_based_on_view_edge(
+        self, edge_view_query, mock_view, test_data_modeling_replicator
+    ):
+        # Modify the view to be used for edge
+        mock_view["usedFor"] = "edge"
+        # Call the method under test
+        result_query = test_data_modeling_replicator.generate_query_based_on_view(
+            mock_view
+        )
+
+        # Assert that the query is as expected
+        assert result_query == edge_view_query
+
+    def test_generate_query_based_on_edge(
+        self, edge_query, test_data_modeling_replicator
+    ):
+        # Call the method under test
+        result_query = test_data_modeling_replicator.generate_query_based_on_edge()
+
+        # Assert that the query is as expected
+        assert result_query == edge_query
+
+    def test_write_instance_to_lakehouse(
+        self, mock_data_modeling_config, node_view_query, test_data_modeling_replicator
+    ):
+        test_node = Node(
+            space="test_space",
+            external_id="test_id",
+            version="test_version",
+            last_updated_time=12345600,
+            created_time=12345600,
+            deleted_time=12378900,
+            type=None,
+            properties={"prop1": "value1", "prop2": "value2"},
+        )
+        test_data_modeling_replicator.state_store.get_state.return_value = [
+            None,
+            '{"cursor" : "test_cursor"}',
+        ]
+        # Mock the get_instances method
+        test_data_modeling_replicator.send_to_lakehouse = Mock()
+
+        # Mock two responses for instance sync, first with node data second without
+        test_data_modeling_replicator.cognite_client.data_modeling.instances.sync.side_effect = [
+            QueryResult(
+                nodes=NodeListWithCursor(
+                    resources=[test_node],
+                    cursor=None,
+                )
+            ),
+            QueryResult(),
+        ]
+
+        # Call the method under test
+        test_data_modeling_replicator.write_instance_to_lakehouse(
+            mock_data_modeling_config,
+            "state_test_space_test_id_test_version",
+            node_view_query,
+        )
+
+        # Assert that the get_instances method was called with the expected arguments
+        test_data_modeling_replicator.send_to_lakehouse.assert_any_call(
+            data_model_config=mock_data_modeling_config,
+            state_id="state_test_space_test_id_test_version",
+            result=QueryResult(
+                nodes=NodeListWithCursor(
+                    resources=[test_node],
+                    cursor={"cursor": "test_cursor"},
+                )
+            ),
+        )
+
+    def test_get_instances_null(
+        self, query_result_empty, test_data_modeling_replicator
+    ):
+        instances = test_data_modeling_replicator.get_instances(
+            query_result_empty, is_edge=False
+        )
         assert len(instances) == 0
 
-    def test_get_instances_nodes(self, query_result_nodes, expected_node_instance):
+    def test_get_instances_nodes(
+        self, query_result_nodes, expected_node_instance, test_data_modeling_replicator
+    ):
         expected_nodes = expected_node_instance
-        actual_nodes = self.replicator.get_instances(query_result_nodes, is_edge=False)
+        actual_nodes = test_data_modeling_replicator.get_instances(
+            query_result_nodes, is_edge=False
+        )
         assert actual_nodes == expected_nodes
 
-    def test_get_instances_edges(self, query_result_edges, expected_edge_instance):
+    def test_get_instances_edges(
+        self, query_result_edges, expected_edge_instance, test_data_modeling_replicator
+    ):
         expected_edges = expected_edge_instance
-        actual_edges = self.replicator.get_instances(query_result_edges, is_edge=True)
+        actual_edges = test_data_modeling_replicator.get_instances(
+            query_result_edges, is_edge=True
+        )
         assert actual_edges == expected_edges
 
     def test_send_to_lakehouse_null(
-        self, query_result_empty, mock_write_deltalake, replicator_config
+        self,
+        query_result_empty,
+        mock_write_deltalake,
+        replicator_config,
+        test_data_modeling_replicator,
     ):
-        self.replicator.send_to_lakehouse(
+        test_data_modeling_replicator.send_to_lakehouse(
             data_model_config=replicator_config.data_modeling,
             state_id="test_state_id",
             result=query_result_empty,
@@ -254,8 +566,9 @@ class TestDataModelingReplicator:
         replicator_config,
         expected_node_instance,
         lakehouse_abfss_prefix,
+        test_data_modeling_replicator,
     ):
-        self.replicator.send_to_lakehouse(
+        test_data_modeling_replicator.send_to_lakehouse(
             data_model_config=replicator_config.data_modeling,
             state_id="test_state_id",
             result=query_result_nodes,
@@ -272,8 +585,9 @@ class TestDataModelingReplicator:
         replicator_config,
         expected_edge_instance,
         lakehouse_abfss_prefix,
+        test_data_modeling_replicator,
     ):
-        self.replicator.send_to_lakehouse(
+        test_data_modeling_replicator.send_to_lakehouse(
             data_model_config=replicator_config.data_modeling,
             state_id="test_state_id",
             result=query_result_edges,
@@ -281,4 +595,50 @@ class TestDataModelingReplicator:
         mock_write_deltalake.assert_called_once()
         mock_write_deltalake.assert_called_with(
             expected_edge_instance, lakehouse_abfss_prefix
+        )
+
+    @patch(
+        "cdf_fabric_replicator.data_modeling.DefaultAzureCredential.get_token",
+        return_value=Mock(token="test_token"),
+    )
+    @patch("cdf_fabric_replicator.data_modeling.write_deltalake")
+    def test_write_instances_to_lakehouse_tables(
+        self, mock_deltalake_write, mock_token, test_data_modeling_replicator
+    ):
+        test_data = [
+            {
+                "space": "test_space",
+                "instanceType": "node",
+                "externalId": "id1",
+                "version": 1,
+                "lastUpdatedTime": 12345600,
+                "createdTime": 12345600,
+                "prop1": "value1",
+            },
+            {
+                "space": "test_space",
+                "instanceType": "node",
+                "externalId": "id2",
+                "version": 1,
+                "lastUpdatedTime": 12345600,
+                "createdTime": 12345600,
+                "prop1": "value1",
+            },
+        ]
+        pyarrow_data = pa.Table.from_pylist(test_data)
+        test_data_modeling_replicator.write_instances_to_lakehouse_tables(
+            {"test_space_test_view": test_data},
+            "test_abfss_prefix",
+        )
+        mock_token.assert_called_once()
+        mock_deltalake_write.assert_called_once_with(
+            "test_abfss_prefix/Tables/test_space_test_view",
+            pyarrow_data,
+            engine="rust",
+            mode="append",
+            schema_mode="merge",
+            storage_options={
+                "bearer_token": "test_token",
+                "use_fabric_endpoint": "true",
+            },
         )


### PR DESCRIPTION
This PR adds unit tests for the CDF Fabric Data Model Replicator.  Test coverage on `data_modeling.py` is 100% with the addition of these tests.
![Screenshot 2024-05-08 at 11 18 36 AM](https://github.com/cognitedata/cdf-fabric-replicator/assets/17890911/e94667b3-cc11-41d0-a783-c5fd49e82620)
