### PR TITLE
Time Series Replicator Unit Testing - Mock DefaultAzureCredential and Add Tests for Error Handling

### DIFF
--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -13,6 +13,7 @@ from cdf_fabric_replicator.event import EventsReplicator
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.log_config import LOGGING_CONFIG
 
+
 def main() -> None:
     logging.config.dictConfig(LOGGING_CONFIG)
     logging.info("Starting CDF Fabric Replicator")


### PR DESCRIPTION
This PR includes the following changes:

- Mocks `DefaultAzureCredential` so that time series replicator unit tests can run in the Github Action without requiring secrets
- Adds tests that cover error handling added in #85 