### PR TITLE
Events Replicator Unit Testing

### DIFF
--- a/cdf_fabric_replicator/__main__.py
+++ b/cdf_fabric_replicator/__main__.py
@@ -13,6 +13,7 @@ from cdf_fabric_replicator.event import EventsReplicator
 from cdf_fabric_replicator.metrics import Metrics
 from cdf_fabric_replicator.log_config import LOGGING_CONFIG
 
+
 def main() -> None:
     logging.config.dictConfig(LOGGING_CONFIG)
     logging.info("Starting CDF Fabric Replicator")

--- a/cdf_fabric_replicator/event.py
+++ b/cdf_fabric_replicator/event.py
@@ -38,7 +38,7 @@ class EventsReplicator(Extractor):
             logging.info("No event config found in config")
             return
 
-        while True:  # not self.stop_event.is_set():
+        while not self.stop_event.is_set():
             start_time = time.time()  # Get the current time in seconds
 
             self.process_events()

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -6,15 +6,23 @@ import pyarrow as pa
 
 EVENT_BATCH_SIZE = 1
 
+
 @pytest.fixture()
 def test_event_replicator():
-    event_replicator = EventsReplicator(metrics=Mock(), stop_event=Mock())
-    event_replicator.config = Mock(event=Mock(batch_size=EVENT_BATCH_SIZE, lakehouse_abfss_path_events="Events"), extractor=Mock(poll_time=1))
-    event_replicator.client = Mock()
-    event_replicator.state_store = Mock()
-    event_replicator.cognite_client = Mock()
-    event_replicator.azure_credential = Mock(get_token=Mock(return_value=Mock(token="token")))
-    return event_replicator
+    with patch("cdf_fabric_replicator.event.DefaultAzureCredential") as mock_credential:
+        mock_credential.return_value.get_token.return_value = Mock(token="token")
+        event_replicator = EventsReplicator(metrics=Mock(), stop_event=Mock())
+        event_replicator.config = Mock(
+            event=Mock(
+                batch_size=EVENT_BATCH_SIZE, lakehouse_abfss_path_events="Events"
+            ),
+            extractor=Mock(poll_time=1),
+        )
+        event_replicator.client = Mock()
+        event_replicator.state_store = Mock()
+        event_replicator.cognite_client = Mock()
+        return event_replicator
+
 
 @pytest.fixture
 def event():
@@ -39,6 +47,7 @@ def event():
         "created_time": 1710503304020,
     }
 
+
 @patch("cdf_fabric_replicator.event.time.sleep")
 @patch("cdf_fabric_replicator.event.EventsReplicator.process_events")
 def test_run(mock_process_events, mock_sleep, test_event_replicator):
@@ -48,27 +57,45 @@ def test_run(mock_process_events, mock_sleep, test_event_replicator):
     mock_process_events.assert_called_once()
     mock_sleep.assert_called_once()
 
+
 @patch("cdf_fabric_replicator.event.logging.info")
 def test_run_no_event_config(mock_logging, test_event_replicator):
     test_event_replicator.config.event = None
     test_event_replicator.run()
     mock_logging.assert_called_with("No event config found in config")
 
-@pytest.mark.parametrize("last_created_time, event_query_time", [(None, 1), (1714685606, 1714685607)])
+
+@pytest.mark.parametrize(
+    "last_created_time, event_query_time", [(None, 1), (1714685606, 1714685607)]
+)
 @patch("cdf_fabric_replicator.event.write_deltalake")
-def test_process_events(mock_write_deltalake, event, test_event_replicator, last_created_time, event_query_time):
+def test_process_events(
+    mock_write_deltalake,
+    event,
+    test_event_replicator,
+    last_created_time,
+    event_query_time,
+):
     # Set up empty state and cognite client events iterator
-    test_event_replicator.state_store.get_state.return_value = [(None,last_created_time)]
-    test_event_replicator.cognite_client.events = Mock(return_value=iter([Event(**event)]))
+    test_event_replicator.state_store.get_state.return_value = [
+        (None, last_created_time)
+    ]
+    test_event_replicator.cognite_client.events = Mock(
+        return_value=iter([Event(**event)])
+    )
 
     # Run the process_events method
     test_event_replicator.process_events()
 
     # State store assertions
-    test_event_replicator.state_store.get_state.assert_called_once_with(external_id="event_state")
-    test_event_replicator.state_store.set_state.assert_called_once_with(external_id="event_state", high=event["created_time"])
+    test_event_replicator.state_store.get_state.assert_called_once_with(
+        external_id="event_state"
+    )
+    test_event_replicator.state_store.set_state.assert_called_once_with(
+        external_id="event_state", high=event["created_time"]
+    )
     test_event_replicator.state_store.synchronize.assert_called_once()
-    
+
     # Cognite client assertions
     test_event_replicator.cognite_client.events.assert_called_with(
         chunk_size=EVENT_BATCH_SIZE,


### PR DESCRIPTION
Adds unit tests for CDF Fabric Events Replicator.  Coverage for `events.py` is 99% after the addition of these tests.