### PR TITLE
Events updates; filter on dataset, md5 key supprt in fabric tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,11 @@ cython_debug/
 states.json
 
 debug.log.*
+state2.json
+example_config_abp.yaml
+.env_am
+.env.akerbppilot
+poetry.lock
+example_config_am.yml
+extractor-state.json
+Events/*

--- a/cdf_fabric_replicator/config.py
+++ b/cdf_fabric_replicator/config.py
@@ -30,6 +30,7 @@ class DataModelingConfig:
 @dataclass
 class EventConfig:
     lakehouse_abfss_path_events: str
+    dataset_external_id: str
     batch_size: int = 1000
 
 
@@ -38,7 +39,9 @@ class RawConfig:
     table_name: str
     db_name: str
     raw_path: str
-    incremental_field: str
+    key_fields: Optional[List[str]]
+    incremental_field: Optional[str]
+    md5_key: bool = False
 
 
 @dataclass

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -23,7 +23,7 @@ from deltalake.exceptions import DeltaError
 from deltalake import write_deltalake
 import pyarrow as pa
 
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 from cdf_fabric_replicator.config import Config, DataModelingConfig
 from cdf_fabric_replicator.metrics import Metrics
 
@@ -41,7 +41,7 @@ class DataModelingReplicator(Extractor):
             config_class=Config,
             metrics=metrics,
             use_default_state_store=False,
-            version=__version__,
+            version=fabric_replicator_version,
             cancellation_token=stop_event,
             config_file_path=override_config_path,
         )

--- a/cdf_fabric_replicator/event.py
+++ b/cdf_fabric_replicator/event.py
@@ -9,7 +9,7 @@ from azure.identity import DefaultAzureCredential
 from deltalake import DeltaTable, write_deltalake
 from deltalake.exceptions import DeltaError
 
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 from cdf_fabric_replicator.config import Config
 from cdf_fabric_replicator.metrics import Metrics
 from cognite.client.data_classes import Event, EventList, ExtractionPipelineRunWrite
@@ -30,7 +30,7 @@ class EventsReplicator(Extractor):
             config_class=Config,
             metrics=metrics,
             use_default_state_store=False,
-            version=__version__,
+            version=fabric_replicator_version,
             cancellation_token=stop_event,
             config_file_path=override_config_path,
         )

--- a/cdf_fabric_replicator/event.py
+++ b/cdf_fabric_replicator/event.py
@@ -149,7 +149,7 @@ class EventsReplicator(Extractor):
         storage_options = {
             "bearer_token": token.token,
             "timeout": "1800s",
-            # "use_fabric_endpoint": "true",
+            "use_fabric_endpoint": "true",
         }
 
         dt = DeltaTable(abfss_path, storage_options=storage_options)
@@ -175,7 +175,7 @@ class EventsReplicator(Extractor):
         data = pa.Table.from_pylist(events)
         storage_options = {
             "bearer_token": token.token,
-            # "use_fabric_endpoint": "true",
+            "use_fabric_endpoint": "true",
         }
 
         try:

--- a/cdf_fabric_replicator/event.py
+++ b/cdf_fabric_replicator/event.py
@@ -1,17 +1,20 @@
+import json
 import logging
 import time
-from typing import Iterator, List, Dict, Any, Optional
-from cognite.extractorutils.base import CancellationToken
-from cognite.extractorutils.base import Extractor
-from azure.identity import DefaultAzureCredential
-from deltalake import write_deltalake, DeltaTable
-from deltalake.exceptions import DeltaError, TableNotFoundError
+from datetime import datetime
+from typing import Any, Dict, Iterator, List, Literal, Optional
+
 import pyarrow as pa
+from azure.identity import DefaultAzureCredential
+from deltalake import DeltaTable, write_deltalake
+from deltalake.exceptions import DeltaError
+
 from cdf_fabric_replicator import __version__
 from cdf_fabric_replicator.config import Config
 from cdf_fabric_replicator.metrics import Metrics
-from cognite.client.data_classes import EventList, Event
-from datetime import datetime
+from cognite.client.data_classes import Event, EventList, ExtractionPipelineRunWrite
+from cognite.client.exceptions import CogniteAPIError
+from cognite.extractorutils.base import CancellationToken, Extractor
 
 
 class EventsReplicator(Extractor):
@@ -58,11 +61,14 @@ class EventsReplicator(Extractor):
             if sleep_time > 0:
                 self.logger.debug(f"Sleep for {sleep_time} seconds")
                 self.stop_event.wait(sleep_time)
+            self.run_extraction_pipeline(status="seen")
 
         self.logger.info("Stop event set. Exiting...")
 
     def process_events(self) -> None:
         limit = self.config.event.batch_size
+        dataset_external_id = self.config.event.dataset_external_id
+
         last_created_time = self.get_event_state(self.event_state_key)
 
         if last_created_time is None:
@@ -73,27 +79,38 @@ class EventsReplicator(Extractor):
                 f"Last created time: {datetime.fromtimestamp(last_created_time / 1000).isoformat()}"
             )
 
-        for event_list in self.get_events(limit, last_created_time):
+        optimize = False
+        for event_list in self.get_events(
+            limit, last_created_time, dataset_external_id
+        ):
             events_dict = event_list.dump()
             if len(events_dict) > 0:
                 if isinstance(events_dict, dict):
                     events_dict = [events_dict]
+
+                for event in events_dict:
+                    event["metadata"] = json.dumps(event["metadata"])
+
                 try:
                     self.write_events_to_lakehouse_tables(
                         events_dict, self.config.event.lakehouse_abfss_path_events
                     )
+                    optimize = True
                 except DeltaError as e:
-                    self.logger.error(f"Error writing events to lakehouse tables: {e}")
+                    self.logger.error(f"Error writing events to delta tables: {e}")
                     raise e
                 last_event = events_dict[-1]
                 self.set_event_state(self.event_state_key, last_event["createdTime"])
             else:
                 self.logger.info("No events found in current batch.")
+        if optimize:
+            self.optimize_table(self.config.event.lakehouse_abfss_path_events)
 
     def get_events(
-        self, limit: int, last_created_time: int
+        self, limit: int, last_created_time: int, dataset_external_id: str
     ) -> Iterator[Event] | Iterator[EventList]:
-        # only pull events that created after last_created_time (hence the +1); assuming no other events are created at the same time
+        # only pull events that created after last_created_time (hence the +1); assuming no other
+        # events are created at the same time
         self.logger.debug(
             f"Getting events with limit: {limit}, last_created_time: {last_created_time}"
         )
@@ -101,6 +118,7 @@ class EventsReplicator(Extractor):
             chunk_size=limit,
             created_time={"min": last_created_time + 1},
             sort=("createdTime", "asc"),
+            data_set_external_ids=[dataset_external_id],
         )
 
     def get_event_state(self, event_state_key: str) -> int | None:
@@ -117,49 +135,80 @@ class EventsReplicator(Extractor):
     def write_or_merge_to_lakehouse_table(
         self, abfss_path: str, storage_options: Dict[str, str], data: pa.Table
     ) -> None:
-        try:
-            dt = DeltaTable(
-                abfss_path,
-                storage_options=storage_options,
-            )
+        write_deltalake(
+            abfss_path,
+            data,
+            mode="append",
+            engine="rust",
+            schema_mode="merge",
+            storage_options=storage_options,
+        )
 
-            (
-                dt.merge(
-                    source=data,
-                    predicate="s.id = t.id",
-                    source_alias="s",
-                    target_alias="t",
-                )
-                .when_matched_update_all()
-                .when_not_matched_insert_all()
-                .execute()
+    def optimize_table(self, abfss_path: str) -> None:
+        token = self.azure_credential.get_token("https://storage.azure.com/.default")
+        storage_options = {
+            "bearer_token": token.token,
+            "timeout": "1800s",
+            # "use_fabric_endpoint": "true",
+        }
+
+        dt = DeltaTable(abfss_path, storage_options=storage_options)
+        try:
+            self.logger.debug(f"Compacting table: {abfss_path}")
+            self.logger.debug(dt.optimize.compact(target_size=256 * 1024 * 1024))
+            self.logger.debug(f"Vacuuming table: {abfss_path}")
+            self.logger.debug(
+                dt.vacuum(retention_hours=1, enforce_retention_duration=False)
             )
-        except TableNotFoundError:
-            write_deltalake(
-                abfss_path,
-                data,
-                mode="append",
-                engine="rust",
-                schema_mode="merge",
-                storage_options=storage_options,
-            )
+            dt.create_checkpoint()
+            self.logger.debug("Done optimizing table.")
+        except DeltaError as e:
+            self.logger.error(f"Error optimizing table: {e}")
+            raise e
 
     def write_events_to_lakehouse_tables(
         self, events: List[Dict[str, Any]], abfss_path: str
     ) -> None:
         token = self.azure_credential.get_token("https://storage.azure.com/.default")
 
-        self.logger.info(f"Writing {len(events)} to '{abfss_path}' table...")
+        self.logger.info(f"Writing {len(events)} events to '{abfss_path}' table...")
         data = pa.Table.from_pylist(events)
         storage_options = {
             "bearer_token": token.token,
-            "use_fabric_endpoint": "true",
+            # "use_fabric_endpoint": "true",
         }
 
         try:
             self.write_or_merge_to_lakehouse_table(abfss_path, storage_options, data)
+            self.run_extraction_pipeline(
+                status="success", message=f"{len(data)} events written to delta table."
+            )
         except DeltaError as e:
-            self.logger.error(f"Error writing events to lakehouse tables: {e}")
+            self.logger.error(f"Error writing events to delta tables: {e}")
             raise e
 
         self.logger.info("done.")
+
+    def run_extraction_pipeline(
+        self, status: Literal["success", "failure", "seen"], message: str = ""
+    ) -> None:
+        if self.config.cognite.extraction_pipeline:
+            try:
+                self.cognite_client.extraction_pipelines.runs.create(
+                    ExtractionPipelineRunWrite(
+                        status=status,
+                        extpipe_external_id=str(
+                            self.config.cognite.extraction_pipeline.external_id
+                        ),
+                        message=message,
+                    )
+                )
+            except CogniteAPIError as e:
+                self.logger.error(f"Error while running extraction pipeline: {e}")
+                raise e
+
+    def _report_success(self) -> None:
+        """
+        Called on a successful exit of the extractor - get rid of "Shutdown success" message that spams the logs.
+        """
+        pass

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -461,8 +461,8 @@ class CdfFabricExtractor(Extractor[Config]):
                     if md5_key:
                         df["md5_key"] = self.get_md5_series_from_dataframe(df)
                         df.set_index("md5_key", inplace=True)
-                    elif incremental_field:
-                        df.set_index(key_fields, inplace=True)
+                    #                    elif incremental_field:
+                    #                         df.set_index(key_fields, inplace=True)
 
                     yield df
 

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -295,6 +295,7 @@ class CdfFabricExtractor(Extractor[Config]):
                         message=f"{len(events)} events inserted to CDF",
                     )
                 except CogniteAPIError as e:
+                    self.logger.error(f"Error while writing event data to CDF: {e}")
                     self.run_extraction_pipeline(
                         status="failure",
                         message=f"Error while writing event data to CDF: {e}",
@@ -459,7 +460,9 @@ class CdfFabricExtractor(Extractor[Config]):
                     df = df.replace({np.nan: None})
 
                     if md5_key:
-                        df["md5_key"] = self.get_md5_series_from_dataframe(df)
+                        df["md5_key"] = self.get_md5_series_from_dataframe(
+                            df, key_fields
+                        )
                         df.set_index("md5_key", inplace=True)
                     #                    elif incremental_field:
                     #                         df.set_index(key_fields, inplace=True)

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -16,7 +16,7 @@ from azure.storage.filedatalake import (
 from deltalake import DeltaTable
 from pandas import DataFrame
 
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 from cdf_fabric_replicator.config import Config
 from cdf_fabric_replicator.metrics import Metrics
 from cognite.client.data_classes import (
@@ -43,7 +43,7 @@ class CdfFabricExtractor(Extractor[Config]):
             description="CDF Fabric Extractor",
             config_class=Config,
             metrics=metrics,
-            version=__version__,
+            version=fabric_replicator_version,
             config_file_path=override_config_path,
         )
         self.metrics = metrics

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -524,7 +524,7 @@ class CdfFabricExtractor(Extractor[Config]):
             MD5 hash created from the input values.
         """
         # convert all values to string, concantenate, and encode so can hash
-        full_str = "".join(map(str, input_iterable)).encode("utf-8")
+        full_str = "-".join(map(str, input_iterable)).encode("utf-8")
 
         # create a md5 hash from the complete string
         md5_hash = md5(full_str).hexdigest()

--- a/cdf_fabric_replicator/metrics.py
+++ b/cdf_fabric_replicator/metrics.py
@@ -1,7 +1,7 @@
 from cognite.extractorutils.metrics import BaseMetrics
 from prometheus_client import Counter
 
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 
 
 class Metrics(BaseMetrics):
@@ -10,7 +10,9 @@ class Metrics(BaseMetrics):
     """
 
     def __init__(self) -> None:
-        super(Metrics, self).__init__("cdf_fabric_replicator", __version__)
+        super(Metrics, self).__init__(
+            "cdf_fabric_replicator", fabric_replicator_version
+        )
 
         self.upserts_processed = Counter(
             "cdf_fabric_replicator_upserts_processed", "Number of upserts processed"

--- a/cdf_fabric_replicator/raw.py
+++ b/cdf_fabric_replicator/raw.py
@@ -8,7 +8,7 @@ from azure.identity import DefaultAzureCredential
 from deltalake import write_deltalake, DeltaTable
 from deltalake.exceptions import DeltaError, TableNotFoundError
 import pyarrow as pa
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 from cdf_fabric_replicator.config import Config
 from cdf_fabric_replicator.metrics import Metrics
 from cognite.client.data_classes import RowList
@@ -23,7 +23,7 @@ class RawTableReplicator(Extractor):
             config_class=Config,
             metrics=metrics,
             use_default_state_store=False,
-            version=__version__,
+            version=fabric_replicator_version,
             cancellation_token=stop_event,
         )
         self.azure_credential = DefaultAzureCredential()

--- a/cdf_fabric_replicator/time_series.py
+++ b/cdf_fabric_replicator/time_series.py
@@ -10,7 +10,7 @@ from azure.identity import DefaultAzureCredential
 from deltalake.exceptions import DeltaError, TableNotFoundError
 from deltalake.writer import DeltaTable, write_deltalake
 
-from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import __version__ as fabric_replicator_version
 from cdf_fabric_replicator import subscription as sub
 from cdf_fabric_replicator.config import Config, SubscriptionsConfig
 from cdf_fabric_replicator.metrics import Metrics
@@ -36,7 +36,7 @@ class TimeSeriesReplicator(Extractor):
             config_class=Config,
             metrics=metrics,
             use_default_state_store=False,
-            version=__version__,
+            version=fabric_replicator_version,
             cancellation_token=stop_event,
             config_file_path=override_config_path,
         )

--- a/cdf_fabric_replicator/time_series.py
+++ b/cdf_fabric_replicator/time_series.py
@@ -4,25 +4,23 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Literal, Optional
 
+import numpy as np
+import pandas as pd
 from azure.identity import DefaultAzureCredential
 from deltalake.exceptions import DeltaError, TableNotFoundError
-from deltalake.writer import write_deltalake, DeltaTable
-import pandas as pd
-import numpy as np
+from deltalake.writer import DeltaTable, write_deltalake
 
-from cognite.client.exceptions import CogniteAPIError
+from cdf_fabric_replicator import __version__
+from cdf_fabric_replicator import subscription as sub
+from cdf_fabric_replicator.config import Config, SubscriptionsConfig
+from cdf_fabric_replicator.metrics import Metrics
 from cognite.client.data_classes import ExtractionPipelineRunWrite, TimeSeries
 from cognite.client.data_classes.datapoints_subscriptions import (
     DatapointSubscriptionBatch,
     DatapointsUpdate,
 )
-from cognite.extractorutils.base import Extractor
-from cognite.extractorutils.base import CancellationToken
-
-
-from cdf_fabric_replicator import __version__, subscription as sub
-from cdf_fabric_replicator.config import Config, SubscriptionsConfig
-from cdf_fabric_replicator.metrics import Metrics
+from cognite.client.exceptions import CogniteAPIError
+from cognite.extractorutils.base import CancellationToken, Extractor
 
 
 class TimeSeriesReplicator(Extractor):
@@ -81,16 +79,6 @@ class TimeSeriesReplicator(Extractor):
             start_time = time.time()  # Get the current time in seconds
 
             self.process_subscriptions()
-            try:
-                self.cognite_client.extraction_pipelines.runs.create(
-                    ExtractionPipelineRunWrite(
-                        status="success",
-                        extpipe_external_id=self.config.cognite.extraction_pipeline.external_id,
-                    )
-                )
-            except CogniteAPIError as e:
-                self.logger.error(f"Error creating extraction pipeline run: {e}.")
-                raise e
             end_time = time.time()  # Get the time after function execution
             elapsed_time = end_time - start_time
             sleep_time = max(
@@ -148,6 +136,12 @@ class TimeSeriesReplicator(Extractor):
                         state_id=state_id,
                         send_now=True,
                     )
+                self.cognite_client.extraction_pipelines.runs.create(
+                    ExtractionPipelineRunWrite(
+                        status="success",
+                        extpipe_external_id=self.config.cognite.extraction_pipeline.external_id,
+                    )
+                )
 
                 if not update_batch.has_next:
                     return f"{state_id} no more data at {update_batch.cursor}"

--- a/schema/event_config.schema.json
+++ b/schema/event_config.schema.json
@@ -12,6 +12,11 @@
         "batch-size": {
             "type": "integer",
             "description": "Input the number of events to read in a single batch from CDF."
+        },
+        "dataset_external_id": {
+            "type": "string",
+            "description": "Input the external id of the dataset to pull events from CDF (optional)."
         }
+
     }
 }

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -120,7 +120,7 @@ def test_process_events_new_table(
         schema_mode="merge",
         storage_options={
             "bearer_token": "token",
-            # "use_fabric_endpoint": "true",
+            "use_fabric_endpoint": "true",
         },
     )
 
@@ -169,6 +169,6 @@ def test_write_events_to_lakehouse_tables_merge(
         abfss_path,
         storage_options={
             "bearer_token": "token",
-            # "use_fabric_endpoint": "true",
+            "use_fabric_endpoint": "true",
         },
     )

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -72,7 +72,6 @@ def test_run_no_event_config(test_event_replicator):
     )
 
 
-# @pytest.mark.skip("Error in test")
 @pytest.mark.parametrize(
     "last_created_time, event_query_time", [(None, 1), (1714685606, 1714685607)]
 )

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -147,9 +147,8 @@ def test_process_events_delta_error(mock_deltatable, event, test_event_replicato
     test_event_replicator.logger.error.call_count == 2
 
 
-@pytest.mark.skip("Error in test")
 @patch("cdf_fabric_replicator.event.pa.Table")
-@patch("cdf_fabric_replicator.event.DeltaTable")
+@patch("cdf_fabric_replicator.event.write_deltalake")
 def test_write_events_to_lakehouse_tables_merge(
     mock_deltatable, mock_pa_table, test_event_replicator
 ):
@@ -172,6 +171,10 @@ def test_write_events_to_lakehouse_tables_merge(
     # Check that DeltaTable was called with the correct arguments
     mock_deltatable.assert_called_once_with(
         abfss_path,
+        empty_df,
+        mode="append",
+        engine="rust",
+        schema_mode="merge",
         storage_options={
             "bearer_token": "token",
             "use_fabric_endpoint": "true",

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -92,6 +92,8 @@ def test_process_events_new_table(
         return_value=iter([Event(**event)])
     )
 
+    test_event_replicator.optimize_table = Mock(return_value=None)
+
     # Run the process_events method
     test_event_replicator.process_events()
 

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -357,7 +357,6 @@ def test_write_event_data_to_cdf(
     )
 
 
-@pytest.mark.skip("Error in test")
 def test_write_event_data_asset_ids_not_found(test_extractor, event_data, mocker):
     df = pd.DataFrame(event_data)
     table = pa.Table.from_pandas(df)
@@ -365,8 +364,12 @@ def test_write_event_data_asset_ids_not_found(test_extractor, event_data, mocker
         "cdf_fabric_replicator.extractor.DeltaTable",
         return_value=Mock(
             to_pyarrow_dataset=Mock(
-                return_value=Mock(to_batches=Mock(return_value=iter([table])))
-            )
+                return_value=Mock(
+                    sort_by=Mock(
+                        return_value=Mock(to_batches=Mock(return_value=iter([table])))
+                    )
+                )
+            ),
         ),
     )
     test_extractor.state_store.get_state.return_value = (None,)
@@ -383,7 +386,6 @@ def test_write_event_data_asset_ids_not_found(test_extractor, event_data, mocker
     test_extractor.logger.error.assert_called_once()
 
 
-@pytest.mark.skip("Error in test")
 def test_write_event_data_asset_retrieve_error(test_extractor, event_data, mocker):
     df = pd.DataFrame(event_data)
     table = pa.Table.from_pandas(df)
@@ -391,8 +393,12 @@ def test_write_event_data_asset_retrieve_error(test_extractor, event_data, mocke
         "cdf_fabric_replicator.extractor.DeltaTable",
         return_value=Mock(
             to_pyarrow_dataset=Mock(
-                return_value=Mock(to_batches=Mock(return_value=iter([table])))
-            )
+                return_value=Mock(
+                    sort_by=Mock(
+                        return_value=Mock(to_batches=Mock(return_value=iter([table])))
+                    )
+                )
+            ),
         ),
     )
     test_extractor.state_store.get_state.return_value = (None,)

--- a/tests/unit/test_raw.py
+++ b/tests/unit/test_raw.py
@@ -95,6 +95,7 @@ def test_process_raw_tables(
     # Set up empty state and cognite client rows iterator
     test_raw_replicator.state_store.get_state.return_value = [(last_updated_time, None)]
     test_raw_replicator.cognite_client.raw.rows.list = Mock(side_effect=[rowList, []])
+    test_raw_replicator.config.extractor.use_fabric_endpoint = True
     mock_deltatable.side_effect = TableNotFoundError
 
     # Run the process_raw_tables method


### PR DESCRIPTION
- Feature create in AkerBP Pilot, select only a dataset of events to replicate, not all
- Support creating a md5 key based on all a set up columns when pulling rows from OneLake
- Do some optimizing of delta tables created for events