### PR TITLE
Delete row from DeltaTable on DM sync delete

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install uv and cogex
         run: pip install --no-cache-dir uv cognite-extractor-manager==2.*
@@ -265,7 +265,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: install build dependencies
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install uv
       run: pip install uv

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install u
       run: pip install uv

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -377,7 +377,7 @@ class DataModelingReplicator(Extractor):
             )
             try:
                 dt.delete(
-                    f"externalId IN ({', '.join([f'\'{instance["externalId"]}\'' for instance in instances[table]])})"
+                    f"externalId IN ({', '.join([f"'{instance['externalId']}'" for instance in instances[table]])})"
                 )
 
             except DeltaError as e:

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -1,4 +1,5 @@
 # mypy: ignore-errors
+from collections import defaultdict
 import json
 import logging
 import time
@@ -297,8 +298,8 @@ class DataModelingReplicator(Extractor):
     def get_instances_from_result(
         self, instances_from_result: NodeList | EdgeList
     ) -> tuple[Dict[str, Any], Dict[str, Any]]:
-        instances = {}
-        deleted_instances = {}
+        instances = defaultdict(list)
+        deleted_instances = defaultdict(list)
 
         instance_type = (
             "edge" if isinstance(instances_from_result, EdgeList) else "node"
@@ -336,15 +337,9 @@ class DataModelingReplicator(Extractor):
 
             if instance.deleted_time is not None:
                 item["deletedTime"] = instance.deleted_time
-                if table_name not in deleted_instances:
-                    deleted_instances[table_name] = [item]
-                else:
-                    deleted_instances[table_name].append(item)
+                deleted_instances[table_name].append(item)
             else:
-                if table_name not in instances:
-                    instances[table_name] = [item]
-                else:
-                    instances[table_name].append(item)
+                instances[table_name].append(item)
 
         return (instances, deleted_instances)
 

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -223,7 +223,10 @@ class DataModelingReplicator(Extractor):
         try:
             res = self.cognite_client.data_modeling.instances.sync(query=query)
         except CogniteAPIError as e:
-            if e.code == 400 and e.message == "Invalid cursor provided.":
+            if e.code == 400 and (
+                e.message == "Invalid cursor provided."
+                or e.message == "Cursor has expired. Try again with a new cursor."
+            ):
                 self.logger.warning(
                     "Invalid cursor provided. Resetting cursors to None and retrying."
                 )

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -243,11 +243,11 @@ class DataModelingReplicator(Extractor):
             for node in result.data["nodes"]:
                 if node.get("lastUpdatedTime", 0) >= query_start_time:
                     return True
-            if "edges" in result.data:
-                for edge in result.data["edges"]:
-                    if edge.get("lastUpdatedTime", 0) >= query_start_time:
-                        return True
-            return False
+        if "edges" in result.data:
+            for edge in result.data["edges"]:
+                if edge.get("lastUpdatedTime", 0) >= query_start_time:
+                    return True
+        return False
 
     def send_to_lakehouse(
         self,

--- a/cdf_fabric_replicator/data_modeling.py
+++ b/cdf_fabric_replicator/data_modeling.py
@@ -242,11 +242,11 @@ class DataModelingReplicator(Extractor):
         # Check if any node/edge has lastUpdatedTime >= query_start_time
         if "nodes" in result.data:
             for node in result.data["nodes"]:
-                if node.get("lastUpdatedTime", 0) >= query_start_time:
+                if node.last_updated_time >= query_start_time:
                     return True
         if "edges" in result.data:
             for edge in result.data["edges"]:
-                if edge.get("lastUpdatedTime", 0) >= query_start_time:
+                if edge.last_updated_time >= query_start_time:
                     return True
         return False
 
@@ -393,9 +393,12 @@ class DataModelingReplicator(Extractor):
                 },
             )
             try:
-                dt.delete(
-                    f"externalId IN ({', '.join([f"'{instance['externalId']}'" for instance in instances[table]])})"
-                )
+                xids = [
+                    instance["externalId"].replace("'", "''")
+                    for instance in instances[table]
+                ]
+                predicate = f'externalId IN ({', '.join([f"'{xid}'" for xid in xids])})'
+                dt.delete(predicate)
 
             except DeltaError as e:
                 self.logger.error(

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,6 +21,12 @@ artifacts:
 # A list of releases, when running the release script only the entry matching the
 # provided version is used.
 versions:
+  "0.3.5":
+    description: "Incremental improvements and bug fixes."
+    changelog:
+      added:
+        - "Implement delete functionality for datamodel replicator"
+        - "Stability fixes"
   "0.3.4":
     description: "Incremental improvements and bug fixes."
     changelog:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pywin32>=308 ; sys_platform == 'win32'"
 ]
 name = "cdf_fabric_replicator"
-version = "0.3.4"
+version = "0.3.5"
 description = "Stream data from CDF to Fabric/Onelake"
 
 [project.scripts]

--- a/tests/integration/test_data_model_replicator.py
+++ b/tests/integration/test_data_model_replicator.py
@@ -127,7 +127,7 @@ def instance_table_paths(
 @pytest.fixture(scope="function")
 def example_actor():
     return Node(
-        "arnold_schwarzenegger",
+        "'arnold_schwarzenegger'",
         "Actor",
         {
             "Actor": {"wonOscar": False},
@@ -138,7 +138,7 @@ def example_actor():
 
 @pytest.fixture(scope="function")
 def updated_actor():
-    return Node("arnold_schwarzenegger", "Actor", {"Actor": {"wonOscar": True}})
+    return Node("'arnold_schwarzenegger'", "Actor", {"Actor": {"wonOscar": True}})
 
 
 @pytest.fixture(scope="function")
@@ -151,7 +151,7 @@ def example_movie():
 @pytest.fixture(scope="function")
 def example_edge_actor_to_movie(example_actor, example_movie):
     return Edge(
-        "relation:arnold_schwarzenegger:terminator",
+        "relation:'arnold_schwarzenegger':terminator",
         "movies",
         example_actor,
         example_movie,
@@ -161,7 +161,7 @@ def example_edge_actor_to_movie(example_actor, example_movie):
 @pytest.fixture(scope="function")
 def example_edge_movie_to_actor(example_actor, example_movie):
     return Edge(
-        "relation:terminator:arnold_schwarzenegger",
+        "relation:terminator:'arnold_schwarzenegger'",
         "actors",
         example_movie,
         example_actor,

--- a/uv.lock
+++ b/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "cdf-fabric-replicator"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
* Implement deletion in data modeling replicator.
Data model instances are now deleted if deletedTime != null. Previously it was an update, making the deletes visible with deletedTime in OneLake.

* Fix: Only reset cursor on 400 == "Invalid cursor provided."
* Fix: Sync only instances which are <= current timestamp