### PR TITLE
Adjust CODEOWNERS to be sufficient to assign ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @muradsater
-*       @BergsethCognite
+* @cognitedata/partner-enablement @muradsater @BergsethCognite


### PR DESCRIPTION
For repositories that are built in CD, we require that the ownership of the repository must be a team, not just individual contributors, to clearly signal ownership.

This adds the partner-enablement team, but keeps Murad and Jan Inge in the list so they are also automatically explicitly assigned. Also, Jan-Inge is not an official member of partner-enablement, so he needs to be listed explicitly too.