### PR TITLE
Set state only if incremental_field is provided

### DIFF
--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -338,7 +338,7 @@ class CdfFabricExtractor(Extractor[Config]):
                 self.run_extraction_pipeline(
                     status="success", message=f"{len(df)} rows inserted to {table_name}"
                 )
-                
+
                 if incremental_field:
                     self.set_state(state_id, df[incremental_field].max())
 

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -338,7 +338,9 @@ class CdfFabricExtractor(Extractor[Config]):
                 self.run_extraction_pipeline(
                     status="success", message=f"{len(df)} rows inserted to {table_name}"
                 )
-                self.set_state(state_id, df[incremental_field].max())
+                
+                if incremental_field:
+                    self.set_state(state_id, df[incremental_field].max())
 
             else:
                 self.run_extraction_pipeline(status="seen")

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -303,7 +303,7 @@ class CdfFabricExtractor(Extractor[Config]):
                     raise e
 
                 if incremental_field:
-                    self.set_state(state_id, df[incremental_field].max())
+                    self.set_state(state_id, str(df[incremental_field].max()))
 
             else:
                 self.run_extraction_pipeline(status="seen")
@@ -342,7 +342,7 @@ class CdfFabricExtractor(Extractor[Config]):
                 )
 
                 if incremental_field:
-                    self.set_state(state_id, df[incremental_field].max())
+                    self.set_state(state_id, str(df[incremental_field].max()))
 
             else:
                 self.run_extraction_pipeline(status="seen")

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -303,7 +303,7 @@ class CdfFabricExtractor(Extractor[Config]):
                     raise e
 
                 if incremental_field:
-                    self.set_state(state_id, str(df[incremental_field].max()))
+                    self.set_state(state_id, df[incremental_field].max())
 
             else:
                 self.run_extraction_pipeline(status="seen")
@@ -342,7 +342,7 @@ class CdfFabricExtractor(Extractor[Config]):
                 )
 
                 if incremental_field:
-                    self.set_state(state_id, str(df[incremental_field].max()))
+                    self.set_state(state_id, df[incremental_field].max())
 
             else:
                 self.run_extraction_pipeline(status="seen")

--- a/cdf_fabric_replicator/extractor.py
+++ b/cdf_fabric_replicator/extractor.py
@@ -302,7 +302,9 @@ class CdfFabricExtractor(Extractor[Config]):
                     )
                     raise e
 
-                self.set_state(state_id, df[incremental_field].max())
+                if incremental_field:
+                    self.set_state(state_id, df[incremental_field].max())
+
             else:
                 self.run_extraction_pipeline(status="seen")
 


### PR DESCRIPTION
This PR adds a conditional check to ensure **incremental_field** is not None before accessing it from the data frame.

The **incremental_field** property is optional for RAW table source in the config, therefore the condition check is required to avoid unhandled exceptions